### PR TITLE
Replace anyhow with custom error enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,7 +70,6 @@ dependencies = [
 name = "detours-macro"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "proc-macro2",
  "quote",
  "regex",
@@ -294,7 +287,6 @@ dependencies = [
 name = "re-utilities"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "patternscan",
  "retour",
  "windows",
@@ -304,7 +296,6 @@ dependencies = [
 name = "re-utilities-injector"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "dunce",
  "steamlocate",
  "windows",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ members = ["detours-macro", "injector", "utilities"]
 resolver = "2"
 
 [workspace.dependencies]
-anyhow = "1.0"
 quote = "1.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 syn = { version = "1.0", features = ["full"] }

--- a/detours-macro/Cargo.toml
+++ b/detours-macro/Cargo.toml
@@ -9,7 +9,6 @@ proc-macro = true
 [dependencies]
 regex = "1.5.4"
 
-anyhow = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }

--- a/detours-macro/src/lib.rs
+++ b/detours-macro/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro2::Span;
 use quote::quote;
 use regex::Regex;
 use syn::{
-    parse_macro_input, AttributeArgs, BareFnArg, Error, FnArg, Ident, ItemFn, Lit, Meta,
+    parse_macro_input, AttributeArgs, BareFnArg, Error, FnArg, Ident, ItemFn, Lit, LitStr, Meta,
     NestedMeta, Result, TypeBareFn,
 };
 
@@ -141,7 +141,10 @@ pub fn detour(
 
     let address_block = match args.address {
         Address::Signature(addr_sig) => {
-            let error_string = format!("failed to find {}", signature.ident);
+            let error_string = LitStr::new(
+                &format!("failed to find {}", signature.ident),
+                Span::call_site(),
+            );
             quote! {
                 let address = module.scan(#addr_sig).map_err(|e| {
                     match e {

--- a/detours-macro/src/lib.rs
+++ b/detours-macro/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro2::Span;
 use quote::quote;
 use regex::Regex;
 use syn::{
-    parse_macro_input, AttributeArgs, BareFnArg, Error, FnArg, Ident, ItemFn, Lit, LitStr, Meta,
+    parse_macro_input, AttributeArgs, BareFnArg, Error, FnArg, Ident, ItemFn, Lit, Meta,
     NestedMeta, Result, TypeBareFn,
 };
 
@@ -141,13 +141,22 @@ pub fn detour(
 
     let address_block = match args.address {
         Address::Signature(addr_sig) => {
-            let error_string = LitStr::new(
-                &format!("failed to find {}", signature.ident),
-                Span::call_site(),
-            );
+            let error_string = format!("failed to find {}", signature.ident);
             quote! {
-                use anyhow::Context;
-                let address = module.scan(#addr_sig).context(#error_string)?;
+                let address = module.scan(#addr_sig).map_err(|e| {
+                    match e {
+                        ::re_utilities::Error::PatternScanFailed { context } => {
+                            ::re_utilities::Error::PatternScanFailed {
+                                context: Some(format!(
+                                    "{}: {}",
+                                    #error_string,
+                                    context.unwrap_or_default()
+                                )),
+                            }
+                        }
+                        other => other,
+                    }
+                })?;
             }
         }
         Address::Address(address) => quote! {

--- a/injector/Cargo.toml
+++ b/injector/Cargo.toml
@@ -3,11 +3,11 @@ name = "re-utilities-injector"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
+[target.'cfg(windows)'.dependencies]
 steamlocate = "=2.0.0-beta.2"
 dunce = "1.0"
 
-[dependencies.windows]
+[target.'cfg(windows)'.dependencies.windows]
 features = [
     "Win32_System_Threading",
     "Win32_Foundation",

--- a/injector/Cargo.toml
+++ b/injector/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 steamlocate = "=2.0.0-beta.2"
 dunce = "1.0"
 
-anyhow = { workspace = true }
-
 [dependencies.windows]
 features = [
     "Win32_System_Threading",

--- a/injector/src/error.rs
+++ b/injector/src/error.rs
@@ -1,0 +1,205 @@
+use std::fmt;
+
+/// Error type for re-utilities-injector operations
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to decompose the filename from the payload path
+    FilenameDecomposition,
+    /// I/O operation failed
+    Io {
+        context: Option<String>,
+        source: std::io::Error,
+    },
+    /// Failed to allocate memory in the remote process
+    RemoteMemoryAllocation { source: windows::core::Error },
+    /// Failed to write to process memory
+    WriteMemory { source: windows::core::Error },
+    /// Failed to get module handle
+    GetModuleHandle {
+        module: String,
+        source: windows::core::Error,
+    },
+    /// Failed to get procedure address
+    GetProcAddress {
+        procedure: String,
+        source: windows::core::Error,
+    },
+    /// Failed to create a remote thread
+    CreateRemoteThread {
+        context: String,
+        source: windows::core::Error,
+    },
+    /// DLL injection wait failed
+    InjectionWaitFailed { result: u32 },
+    /// Failed to free remote memory
+    FreeMemory { source: windows::core::Error },
+    /// Failed to get module file name from remote process
+    GetRemoteModuleFileName { source: windows::core::Error },
+    /// Failed to load library
+    LoadLibrary { source: windows::core::Error },
+    /// Invalid export name (contains null byte)
+    InvalidExportName { source: std::ffi::NulError },
+    /// Failed to locate export in module
+    ExportNotFound {
+        export_name: String,
+        source: windows::core::Error,
+    },
+    /// Remote call thread timed out
+    RemoteCallTimeout,
+    /// Remote call thread was abandoned
+    RemoteCallAbandoned,
+    /// Waiting for remote call thread failed
+    RemoteCallWaitFailed { result: u32 },
+    /// Failed to create a toolhelp snapshot
+    CreateSnapshot { source: windows::core::Error },
+    /// Failed to canonicalize a path
+    CanonicalizePath { source: std::io::Error },
+    /// Failed to get first module from snapshot
+    GetFirstModule { source: windows::core::Error },
+    /// Failed to spawn a process
+    SpawnProcess { source: windows::core::Error },
+    /// Failed to locate Steam app
+    SteamAppNotFound { app_id: u32 },
+    /// Steam locate error
+    SteamLocate { source: steamlocate::Error },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::FilenameDecomposition => {
+                write!(f, "failed to decompose filename from payload path")
+            }
+            Error::Io { context, source } => {
+                if let Some(ctx) = context {
+                    write!(f, "{}: {}", ctx, source)
+                } else {
+                    write!(f, "I/O error: {}", source)
+                }
+            }
+            Error::RemoteMemoryAllocation { source } => {
+                write!(f, "failed to allocate memory in remote process: {}", source)
+            }
+            Error::WriteMemory { source } => {
+                write!(f, "failed to write memory: {}", source)
+            }
+            Error::GetModuleHandle { module, source } => {
+                write!(
+                    f,
+                    "failed to get handle for module '{}': {}",
+                    module, source
+                )
+            }
+            Error::GetProcAddress { procedure, source } => {
+                write!(
+                    f,
+                    "failed to get address for procedure '{}': {}",
+                    procedure, source
+                )
+            }
+            Error::CreateRemoteThread { context, source } => {
+                write!(
+                    f,
+                    "failed to create remote thread ({}): {}",
+                    context, source
+                )
+            }
+            Error::InjectionWaitFailed { result } => {
+                write!(f, "failed to inject DLL: wait returned {}", result)
+            }
+            Error::FreeMemory { source } => {
+                write!(f, "failed to free memory: {}", source)
+            }
+            Error::GetRemoteModuleFileName { source } => {
+                write!(f, "failed to get remote module file name: {}", source)
+            }
+            Error::LoadLibrary { source } => {
+                write!(f, "failed to load library: {}", source)
+            }
+            Error::InvalidExportName { source } => {
+                write!(f, "invalid export name: {}", source)
+            }
+            Error::ExportNotFound {
+                export_name,
+                source,
+            } => {
+                write!(f, "failed to locate export '{}': {}", export_name, source)
+            }
+            Error::RemoteCallTimeout => {
+                write!(f, "remote call thread timed out")
+            }
+            Error::RemoteCallAbandoned => {
+                write!(f, "remote call thread was abandoned")
+            }
+            Error::RemoteCallWaitFailed { result } => {
+                write!(f, "waiting for remote call thread failed: {}", result)
+            }
+            Error::CreateSnapshot { source } => {
+                write!(f, "failed to create snapshot: {}", source)
+            }
+            Error::CanonicalizePath { source } => {
+                write!(f, "failed to canonicalize module path: {}", source)
+            }
+            Error::GetFirstModule { source } => {
+                write!(f, "failed to get first module: {}", source)
+            }
+            Error::SpawnProcess { source } => {
+                write!(f, "failed to spawn process: {}", source)
+            }
+            Error::SteamAppNotFound { app_id } => {
+                write!(f, "failed to locate Steam app {}", app_id)
+            }
+            Error::SteamLocate { source } => {
+                write!(f, "Steam locate error: {}", source)
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io { source, .. } => Some(source),
+            Error::RemoteMemoryAllocation { source } => Some(source),
+            Error::WriteMemory { source } => Some(source),
+            Error::GetModuleHandle { source, .. } => Some(source),
+            Error::GetProcAddress { source, .. } => Some(source),
+            Error::CreateRemoteThread { source, .. } => Some(source),
+            Error::FreeMemory { source } => Some(source),
+            Error::GetRemoteModuleFileName { source } => Some(source),
+            Error::LoadLibrary { source } => Some(source),
+            Error::InvalidExportName { source } => Some(source),
+            Error::ExportNotFound { source, .. } => Some(source),
+            Error::CreateSnapshot { source } => Some(source),
+            Error::CanonicalizePath { source } => Some(source),
+            Error::GetFirstModule { source } => Some(source),
+            Error::SpawnProcess { source } => Some(source),
+            Error::SteamLocate { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(source: std::io::Error) -> Self {
+        Error::Io {
+            context: None,
+            source,
+        }
+    }
+}
+
+impl From<std::ffi::NulError> for Error {
+    fn from(source: std::ffi::NulError) -> Self {
+        Error::InvalidExportName { source }
+    }
+}
+
+impl From<steamlocate::Error> for Error {
+    fn from(source: steamlocate::Error) -> Self {
+        Error::SteamLocate { source }
+    }
+}
+
+/// Result type alias for re-utilities-injector operations
+pub type Result<T> = std::result::Result<T, Error>;

--- a/injector/src/error.rs
+++ b/injector/src/error.rs
@@ -1,15 +1,8 @@
 use std::fmt;
 
-/// Error type for re-utilities-injector operations
+/// Windows API errors
 #[derive(Debug)]
-pub enum Error {
-    /// Failed to decompose the filename from the payload path
-    FilenameDecomposition,
-    /// I/O operation failed
-    Io {
-        context: Option<String>,
-        source: std::io::Error,
-    },
+pub enum WindowsError {
     /// Failed to allocate memory in the remote process
     RemoteMemoryAllocation { source: windows::core::Error },
     /// Failed to write to process memory
@@ -37,8 +30,6 @@ pub enum Error {
     GetRemoteModuleFileName { source: windows::core::Error },
     /// Failed to load library
     LoadLibrary { source: windows::core::Error },
-    /// Invalid export name (contains null byte)
-    InvalidExportName { source: std::ffi::NulError },
     /// Failed to locate export in module
     ExportNotFound {
         export_name: String,
@@ -52,16 +43,151 @@ pub enum Error {
     RemoteCallWaitFailed { result: u32 },
     /// Failed to create a toolhelp snapshot
     CreateSnapshot { source: windows::core::Error },
-    /// Failed to canonicalize a path
-    CanonicalizePath { source: std::io::Error },
     /// Failed to get first module from snapshot
     GetFirstModule { source: windows::core::Error },
     /// Failed to spawn a process
     SpawnProcess { source: windows::core::Error },
+}
+
+impl fmt::Display for WindowsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WindowsError::RemoteMemoryAllocation { source } => {
+                write!(f, "failed to allocate memory in remote process: {}", source)
+            }
+            WindowsError::WriteMemory { source } => {
+                write!(f, "failed to write memory: {}", source)
+            }
+            WindowsError::GetModuleHandle { module, source } => {
+                write!(
+                    f,
+                    "failed to get handle for module '{}': {}",
+                    module, source
+                )
+            }
+            WindowsError::GetProcAddress { procedure, source } => {
+                write!(
+                    f,
+                    "failed to get address for procedure '{}': {}",
+                    procedure, source
+                )
+            }
+            WindowsError::CreateRemoteThread { context, source } => {
+                write!(
+                    f,
+                    "failed to create remote thread ({}): {}",
+                    context, source
+                )
+            }
+            WindowsError::InjectionWaitFailed { result } => {
+                write!(f, "failed to inject DLL: wait returned {}", result)
+            }
+            WindowsError::FreeMemory { source } => {
+                write!(f, "failed to free memory: {}", source)
+            }
+            WindowsError::GetRemoteModuleFileName { source } => {
+                write!(f, "failed to get remote module file name: {}", source)
+            }
+            WindowsError::LoadLibrary { source } => {
+                write!(f, "failed to load library: {}", source)
+            }
+            WindowsError::ExportNotFound {
+                export_name,
+                source,
+            } => {
+                write!(f, "failed to locate export '{}': {}", export_name, source)
+            }
+            WindowsError::RemoteCallTimeout => {
+                write!(f, "remote call thread timed out")
+            }
+            WindowsError::RemoteCallAbandoned => {
+                write!(f, "remote call thread was abandoned")
+            }
+            WindowsError::RemoteCallWaitFailed { result } => {
+                write!(f, "waiting for remote call thread failed: {}", result)
+            }
+            WindowsError::CreateSnapshot { source } => {
+                write!(f, "failed to create snapshot: {}", source)
+            }
+            WindowsError::GetFirstModule { source } => {
+                write!(f, "failed to get first module: {}", source)
+            }
+            WindowsError::SpawnProcess { source } => {
+                write!(f, "failed to spawn process: {}", source)
+            }
+        }
+    }
+}
+
+impl std::error::Error for WindowsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            WindowsError::RemoteMemoryAllocation { source } => Some(source),
+            WindowsError::WriteMemory { source } => Some(source),
+            WindowsError::GetModuleHandle { source, .. } => Some(source),
+            WindowsError::GetProcAddress { source, .. } => Some(source),
+            WindowsError::CreateRemoteThread { source, .. } => Some(source),
+            WindowsError::FreeMemory { source } => Some(source),
+            WindowsError::GetRemoteModuleFileName { source } => Some(source),
+            WindowsError::LoadLibrary { source } => Some(source),
+            WindowsError::ExportNotFound { source, .. } => Some(source),
+            WindowsError::CreateSnapshot { source } => Some(source),
+            WindowsError::GetFirstModule { source } => Some(source),
+            WindowsError::SpawnProcess { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Steam-related errors
+#[derive(Debug)]
+pub enum SteamError {
     /// Failed to locate Steam app
-    SteamAppNotFound { app_id: u32 },
+    AppNotFound { app_id: u32 },
     /// Steam locate error
-    SteamLocate { source: steamlocate::Error },
+    Locate { source: steamlocate::Error },
+}
+
+impl fmt::Display for SteamError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SteamError::AppNotFound { app_id } => {
+                write!(f, "failed to locate Steam app {}", app_id)
+            }
+            SteamError::Locate { source } => {
+                write!(f, "Steam locate error: {}", source)
+            }
+        }
+    }
+}
+
+impl std::error::Error for SteamError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SteamError::Locate { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Error type for re-utilities-injector operations
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to decompose the filename from the payload path
+    FilenameDecomposition,
+    /// I/O operation failed
+    Io {
+        context: Option<String>,
+        source: std::io::Error,
+    },
+    /// Invalid export name (contains null byte)
+    InvalidExportName { source: std::ffi::NulError },
+    /// Failed to canonicalize a path
+    CanonicalizePath { source: std::io::Error },
+    /// Windows API error
+    Windows(WindowsError),
+    /// Steam-related error
+    Steam(SteamError),
 }
 
 impl fmt::Display for Error {
@@ -77,81 +203,14 @@ impl fmt::Display for Error {
                     write!(f, "I/O error: {}", source)
                 }
             }
-            Error::RemoteMemoryAllocation { source } => {
-                write!(f, "failed to allocate memory in remote process: {}", source)
-            }
-            Error::WriteMemory { source } => {
-                write!(f, "failed to write memory: {}", source)
-            }
-            Error::GetModuleHandle { module, source } => {
-                write!(
-                    f,
-                    "failed to get handle for module '{}': {}",
-                    module, source
-                )
-            }
-            Error::GetProcAddress { procedure, source } => {
-                write!(
-                    f,
-                    "failed to get address for procedure '{}': {}",
-                    procedure, source
-                )
-            }
-            Error::CreateRemoteThread { context, source } => {
-                write!(
-                    f,
-                    "failed to create remote thread ({}): {}",
-                    context, source
-                )
-            }
-            Error::InjectionWaitFailed { result } => {
-                write!(f, "failed to inject DLL: wait returned {}", result)
-            }
-            Error::FreeMemory { source } => {
-                write!(f, "failed to free memory: {}", source)
-            }
-            Error::GetRemoteModuleFileName { source } => {
-                write!(f, "failed to get remote module file name: {}", source)
-            }
-            Error::LoadLibrary { source } => {
-                write!(f, "failed to load library: {}", source)
-            }
             Error::InvalidExportName { source } => {
                 write!(f, "invalid export name: {}", source)
-            }
-            Error::ExportNotFound {
-                export_name,
-                source,
-            } => {
-                write!(f, "failed to locate export '{}': {}", export_name, source)
-            }
-            Error::RemoteCallTimeout => {
-                write!(f, "remote call thread timed out")
-            }
-            Error::RemoteCallAbandoned => {
-                write!(f, "remote call thread was abandoned")
-            }
-            Error::RemoteCallWaitFailed { result } => {
-                write!(f, "waiting for remote call thread failed: {}", result)
-            }
-            Error::CreateSnapshot { source } => {
-                write!(f, "failed to create snapshot: {}", source)
             }
             Error::CanonicalizePath { source } => {
                 write!(f, "failed to canonicalize module path: {}", source)
             }
-            Error::GetFirstModule { source } => {
-                write!(f, "failed to get first module: {}", source)
-            }
-            Error::SpawnProcess { source } => {
-                write!(f, "failed to spawn process: {}", source)
-            }
-            Error::SteamAppNotFound { app_id } => {
-                write!(f, "failed to locate Steam app {}", app_id)
-            }
-            Error::SteamLocate { source } => {
-                write!(f, "Steam locate error: {}", source)
-            }
+            Error::Windows(e) => write!(f, "{}", e),
+            Error::Steam(e) => write!(f, "{}", e),
         }
     }
 }
@@ -160,21 +219,10 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::Io { source, .. } => Some(source),
-            Error::RemoteMemoryAllocation { source } => Some(source),
-            Error::WriteMemory { source } => Some(source),
-            Error::GetModuleHandle { source, .. } => Some(source),
-            Error::GetProcAddress { source, .. } => Some(source),
-            Error::CreateRemoteThread { source, .. } => Some(source),
-            Error::FreeMemory { source } => Some(source),
-            Error::GetRemoteModuleFileName { source } => Some(source),
-            Error::LoadLibrary { source } => Some(source),
             Error::InvalidExportName { source } => Some(source),
-            Error::ExportNotFound { source, .. } => Some(source),
-            Error::CreateSnapshot { source } => Some(source),
             Error::CanonicalizePath { source } => Some(source),
-            Error::GetFirstModule { source } => Some(source),
-            Error::SpawnProcess { source } => Some(source),
-            Error::SteamLocate { source } => Some(source),
+            Error::Windows(e) => e.source(),
+            Error::Steam(e) => e.source(),
             _ => None,
         }
     }
@@ -197,7 +245,19 @@ impl From<std::ffi::NulError> for Error {
 
 impl From<steamlocate::Error> for Error {
     fn from(source: steamlocate::Error) -> Self {
-        Error::SteamLocate { source }
+        Error::Steam(SteamError::Locate { source })
+    }
+}
+
+impl From<WindowsError> for Error {
+    fn from(source: WindowsError) -> Self {
+        Error::Windows(source)
+    }
+}
+
+impl From<SteamError> for Error {
+    fn from(source: SteamError) -> Self {
+        Error::Steam(source)
     }
 }
 

--- a/injector/src/lib.rs
+++ b/injector/src/lib.rs
@@ -5,7 +5,6 @@ use std::{
     ptr::NonNull,
 };
 
-use anyhow::Context;
 use windows::{
     core::{s, w, Owned, HSTRING, PCSTR},
     Win32::{
@@ -36,7 +35,10 @@ use windows::{
     },
 };
 
+pub mod error;
 pub mod spawn;
+
+pub use error::{Error, Result};
 
 /// Injects a DLL into a process. To get a process handle, use [`get_processes_by_name`] or
 /// functions from [`spawn`].
@@ -45,7 +47,7 @@ pub mod spawn;
 /// injector. For example, a 64-bit injector can only inject into a 64-bit process.
 ///
 /// Returns the path to the injected DLL.
-pub fn inject(process: HANDLE, payload_path: &Path) -> anyhow::Result<PathBuf> {
+pub fn inject(process: HANDLE, payload_path: &Path) -> Result<PathBuf> {
     let injected_payload_path = {
         let decompose_filename = |filename: &Path| {
             Some((
@@ -55,7 +57,7 @@ pub fn inject(process: HANDLE, payload_path: &Path) -> anyhow::Result<PathBuf> {
         };
 
         let (stem, extension) =
-            decompose_filename(payload_path).context("failed to decompose filename")?;
+            decompose_filename(payload_path).ok_or(Error::FilenameDecomposition)?;
 
         let injected_payload_filename = Path::new(&(stem + "_loaded")).with_extension(extension);
         payload_path.with_file_name(&injected_payload_filename)
@@ -84,10 +86,9 @@ pub fn inject(process: HANDLE, payload_path: &Path) -> anyhow::Result<PathBuf> {
             PAGE_EXECUTE_READWRITE,
         );
         if alloc.is_null() {
-            anyhow::bail!(
-                "failed to allocate memory in remote process: {:?}",
-                windows::core::Error::from_thread()
-            );
+            return Err(Error::RemoteMemoryAllocation {
+                source: windows::core::Error::from_thread(),
+            });
         }
 
         // Write the DLL path to the target process
@@ -99,17 +100,20 @@ pub fn inject(process: HANDLE, payload_path: &Path) -> anyhow::Result<PathBuf> {
             dll_path.len() * std::mem::size_of::<u16>(),
             Some(&mut bytes_written),
         )
-        .context("failed to write memory")?;
+        .map_err(|e| Error::WriteMemory { source: e })?;
 
         // Get the address of LoadLibraryW
         let kernel32_module =
-            GetModuleHandleW(w!("kernel32.dll")).context("failed to get module")?;
+            GetModuleHandleW(w!("kernel32.dll")).map_err(|e| Error::GetModuleHandle {
+                module: "kernel32.dll".to_string(),
+                source: e,
+            })?;
         let load_library = GetProcAddress(kernel32_module, s!("LoadLibraryW"));
         let Some(load_library) = load_library else {
-            anyhow::bail!(
-                "failed to get LoadLibraryW address: {:?}",
-                windows::core::Error::from_thread()
-            );
+            return Err(Error::GetProcAddress {
+                procedure: "LoadLibraryW".to_string(),
+                source: windows::core::Error::from_thread(),
+            });
         };
 
         // Create a remote thread to load the DLL
@@ -124,17 +128,21 @@ pub fn inject(process: HANDLE, payload_path: &Path) -> anyhow::Result<PathBuf> {
                 0,
                 None,
             )
-            .context("failed to create remote thread")?,
+            .map_err(|e| Error::CreateRemoteThread {
+                context: "DLL injection".to_string(),
+                source: e,
+            })?,
         );
 
         // Wait for thread to finish
         let result = WaitForSingleObject(*thread_handle, 5000);
         if result == WAIT_ABANDONED || result == WAIT_TIMEOUT || result.0 == INFINITE {
-            anyhow::bail!("failed to inject DLL: {result:?}");
+            return Err(Error::InjectionWaitFailed { result: result.0 });
         }
 
         // Free memory
-        VirtualFreeEx(process, alloc, 0, MEM_RELEASE).context("failed to free memory")?;
+        VirtualFreeEx(process, alloc, 0, MEM_RELEASE)
+            .map_err(|e| Error::FreeMemory { source: e })?;
     }
 
     Ok(injected_payload_path)
@@ -146,7 +154,7 @@ pub fn call_remote_export(
     remote_module_base: NonNull<u8>,
     export_name: &str,
     timeout: Option<std::time::Duration>,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     unsafe {
         // Get the module file name from the remote process
         let mut module_path = [0u16; MAX_PATH as usize];
@@ -156,10 +164,9 @@ pub fn call_remote_export(
             &mut module_path,
         );
         if result == 0 {
-            anyhow::bail!(
-                "Failed to get remote export call module path: {:?}",
-                windows::core::Error::from_thread()
-            );
+            return Err(Error::GetRemoteModuleFileName {
+                source: windows::core::Error::from_thread(),
+            });
         }
         let module_path = OsString::from_wide(&module_path);
 
@@ -171,18 +178,17 @@ pub fn call_remote_export(
             None,
             DONT_RESOLVE_DLL_REFERENCES,
         )
-        .context("failed to load library")?;
+        .map_err(|e| Error::LoadLibrary { source: e })?;
 
         // Get the address of the export in our local copy of the DLL
-        let export_name_cstr =
-            std::ffi::CString::new(export_name).context("Invalid export name")?;
+        let export_name_cstr = std::ffi::CString::new(export_name)?;
         let local_addr =
             GetProcAddress(local_module, PCSTR(export_name_cstr.as_ptr() as *const u8));
         let Some(local_addr) = local_addr else {
-            anyhow::bail!(
-                "Failed to locate remote call export: {:?}",
-                windows::core::Error::from_thread()
-            );
+            return Err(Error::ExportNotFound {
+                export_name: export_name.to_string(),
+                source: windows::core::Error::from_thread(),
+            });
         };
 
         // Calculate the remote address by subtracting the local module base
@@ -204,7 +210,10 @@ pub fn call_remote_export(
                 0,
                 None,
             )
-            .context("Failed to create remote call thread")?,
+            .map_err(|e| Error::CreateRemoteThread {
+                context: "remote export call".to_string(),
+                source: e,
+            })?,
         );
 
         // Wait for the thread to complete
@@ -215,28 +224,19 @@ pub fn call_remote_export(
 
         match result {
             WAIT_OBJECT_0 => Ok(()),
-            WAIT_TIMEOUT => {
-                anyhow::bail!("Remote call thread timed out");
-            }
-            WAIT_ABANDONED => {
-                anyhow::bail!("Remote call thread was abandoned");
-            }
-            _ => {
-                anyhow::bail!("Waiting for remote call thread failed: {}", result.0);
-            }
+            WAIT_TIMEOUT => Err(Error::RemoteCallTimeout),
+            WAIT_ABANDONED => Err(Error::RemoteCallAbandoned),
+            _ => Err(Error::RemoteCallWaitFailed { result: result.0 }),
         }
     }
 }
 
 /// Returns the base address of a module in a remote process.
-pub fn get_remote_module_base(
-    process_id: u32,
-    module_path: &Path,
-) -> anyhow::Result<Option<NonNull<u8>>> {
+pub fn get_remote_module_base(process_id: u32, module_path: &Path) -> Result<Option<NonNull<u8>>> {
     let th = unsafe {
         Owned::new(
             CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, process_id)
-                .context("failed to create snapshot")?,
+                .map_err(|e| Error::CreateSnapshot { source: e })?,
         )
     };
 
@@ -247,10 +247,10 @@ pub fn get_remote_module_base(
 
     let module_path = module_path
         .canonicalize()
-        .context("failed to canonicalize module path")?;
+        .map_err(|e| Error::CanonicalizePath { source: e })?;
 
     unsafe {
-        Module32FirstW(*th, &mut entry).context("failed to get first module")?;
+        Module32FirstW(*th, &mut entry).map_err(|e| Error::GetFirstModule { source: e })?;
 
         loop {
             let len = entry
@@ -259,7 +259,9 @@ pub fn get_remote_module_base(
                 .position(|&c| c == 0)
                 .unwrap_or(entry.szExePath.len());
 
-            if PathBuf::from(&*OsString::from_wide(&entry.szExePath[..len])).canonicalize()?
+            if PathBuf::from(&*OsString::from_wide(&entry.szExePath[..len]))
+                .canonicalize()
+                .map_err(|e| Error::CanonicalizePath { source: e })?
                 == module_path
             {
                 return Ok(NonNull::new(entry.modBaseAddr));

--- a/injector/src/lib.rs
+++ b/injector/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "windows")]
+
 use std::{
     ffi::OsString,
     os::windows::ffi::{OsStrExt, OsStringExt},
@@ -38,7 +40,7 @@ use windows::{
 pub mod error;
 pub mod spawn;
 
-pub use error::{Error, Result};
+pub use error::{Error, Result, SteamError, WindowsError};
 
 /// Injects a DLL into a process. To get a process handle, use [`get_processes_by_name`] or
 /// functions from [`spawn`].
@@ -86,9 +88,10 @@ pub fn inject(process: HANDLE, payload_path: &Path) -> Result<PathBuf> {
             PAGE_EXECUTE_READWRITE,
         );
         if alloc.is_null() {
-            return Err(Error::RemoteMemoryAllocation {
+            return Err(WindowsError::RemoteMemoryAllocation {
                 source: windows::core::Error::from_thread(),
-            });
+            }
+            .into());
         }
 
         // Write the DLL path to the target process
@@ -100,20 +103,21 @@ pub fn inject(process: HANDLE, payload_path: &Path) -> Result<PathBuf> {
             dll_path.len() * std::mem::size_of::<u16>(),
             Some(&mut bytes_written),
         )
-        .map_err(|e| Error::WriteMemory { source: e })?;
+        .map_err(|e| WindowsError::WriteMemory { source: e })?;
 
         // Get the address of LoadLibraryW
         let kernel32_module =
-            GetModuleHandleW(w!("kernel32.dll")).map_err(|e| Error::GetModuleHandle {
+            GetModuleHandleW(w!("kernel32.dll")).map_err(|e| WindowsError::GetModuleHandle {
                 module: "kernel32.dll".to_string(),
                 source: e,
             })?;
         let load_library = GetProcAddress(kernel32_module, s!("LoadLibraryW"));
         let Some(load_library) = load_library else {
-            return Err(Error::GetProcAddress {
+            return Err(WindowsError::GetProcAddress {
                 procedure: "LoadLibraryW".to_string(),
                 source: windows::core::Error::from_thread(),
-            });
+            }
+            .into());
         };
 
         // Create a remote thread to load the DLL
@@ -128,7 +132,7 @@ pub fn inject(process: HANDLE, payload_path: &Path) -> Result<PathBuf> {
                 0,
                 None,
             )
-            .map_err(|e| Error::CreateRemoteThread {
+            .map_err(|e| WindowsError::CreateRemoteThread {
                 context: "DLL injection".to_string(),
                 source: e,
             })?,
@@ -137,12 +141,12 @@ pub fn inject(process: HANDLE, payload_path: &Path) -> Result<PathBuf> {
         // Wait for thread to finish
         let result = WaitForSingleObject(*thread_handle, 5000);
         if result == WAIT_ABANDONED || result == WAIT_TIMEOUT || result.0 == INFINITE {
-            return Err(Error::InjectionWaitFailed { result: result.0 });
+            return Err(WindowsError::InjectionWaitFailed { result: result.0 }.into());
         }
 
         // Free memory
         VirtualFreeEx(process, alloc, 0, MEM_RELEASE)
-            .map_err(|e| Error::FreeMemory { source: e })?;
+            .map_err(|e| WindowsError::FreeMemory { source: e })?;
     }
 
     Ok(injected_payload_path)
@@ -164,9 +168,10 @@ pub fn call_remote_export(
             &mut module_path,
         );
         if result == 0 {
-            return Err(Error::GetRemoteModuleFileName {
+            return Err(WindowsError::GetRemoteModuleFileName {
                 source: windows::core::Error::from_thread(),
-            });
+            }
+            .into());
         }
         let module_path = OsString::from_wide(&module_path);
 
@@ -178,17 +183,18 @@ pub fn call_remote_export(
             None,
             DONT_RESOLVE_DLL_REFERENCES,
         )
-        .map_err(|e| Error::LoadLibrary { source: e })?;
+        .map_err(|e| WindowsError::LoadLibrary { source: e })?;
 
         // Get the address of the export in our local copy of the DLL
         let export_name_cstr = std::ffi::CString::new(export_name)?;
         let local_addr =
             GetProcAddress(local_module, PCSTR(export_name_cstr.as_ptr() as *const u8));
         let Some(local_addr) = local_addr else {
-            return Err(Error::ExportNotFound {
+            return Err(WindowsError::ExportNotFound {
                 export_name: export_name.to_string(),
                 source: windows::core::Error::from_thread(),
-            });
+            }
+            .into());
         };
 
         // Calculate the remote address by subtracting the local module base
@@ -210,7 +216,7 @@ pub fn call_remote_export(
                 0,
                 None,
             )
-            .map_err(|e| Error::CreateRemoteThread {
+            .map_err(|e| WindowsError::CreateRemoteThread {
                 context: "remote export call".to_string(),
                 source: e,
             })?,
@@ -224,9 +230,9 @@ pub fn call_remote_export(
 
         match result {
             WAIT_OBJECT_0 => Ok(()),
-            WAIT_TIMEOUT => Err(Error::RemoteCallTimeout),
-            WAIT_ABANDONED => Err(Error::RemoteCallAbandoned),
-            _ => Err(Error::RemoteCallWaitFailed { result: result.0 }),
+            WAIT_TIMEOUT => Err(WindowsError::RemoteCallTimeout.into()),
+            WAIT_ABANDONED => Err(WindowsError::RemoteCallAbandoned.into()),
+            _ => Err(WindowsError::RemoteCallWaitFailed { result: result.0 }.into()),
         }
     }
 }
@@ -236,7 +242,7 @@ pub fn get_remote_module_base(process_id: u32, module_path: &Path) -> Result<Opt
     let th = unsafe {
         Owned::new(
             CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, process_id)
-                .map_err(|e| Error::CreateSnapshot { source: e })?,
+                .map_err(|e| WindowsError::CreateSnapshot { source: e })?,
         )
     };
 
@@ -250,7 +256,7 @@ pub fn get_remote_module_base(process_id: u32, module_path: &Path) -> Result<Opt
         .map_err(|e| Error::CanonicalizePath { source: e })?;
 
     unsafe {
-        Module32FirstW(*th, &mut entry).map_err(|e| Error::GetFirstModule { source: e })?;
+        Module32FirstW(*th, &mut entry).map_err(|e| WindowsError::GetFirstModule { source: e })?;
 
         loop {
             let len = entry

--- a/injector/src/spawn.rs
+++ b/injector/src/spawn.rs
@@ -5,7 +5,7 @@ use windows::{
     Win32::{Foundation::HANDLE, System::Threading},
 };
 
-use crate::error::{Error, Result};
+use crate::error::{Result, SteamError, WindowsError};
 
 /// An owned variant of `Threading::PROCESS_INFORMATION`.
 pub struct ProcessInformation {
@@ -80,7 +80,7 @@ pub fn arbitrary_process<'a>(
             &mut process_info,
         )
         .map(|_| process_info.into())
-        .map_err(|e| Error::SpawnProcess { source: e })
+        .map_err(|e| WindowsError::SpawnProcess { source: e }.into())
     }
 }
 
@@ -95,7 +95,7 @@ pub fn steam_process<'a>(
 
     let (app, library) = steam_dir
         .find_app(app_id)?
-        .ok_or(Error::SteamAppNotFound { app_id })?;
+        .ok_or(SteamError::AppNotFound { app_id })?;
     let game_path = library.resolve_app_dir(&app);
     let executable_path = executable_path_builder(&game_path);
 

--- a/injector/src/spawn.rs
+++ b/injector/src/spawn.rs
@@ -1,10 +1,11 @@
-use anyhow::Context;
 use std::path::{Path, PathBuf};
 
 use windows::{
     core::{Owned, HSTRING, PWSTR},
     Win32::{Foundation::HANDLE, System::Threading},
 };
+
+use crate::error::{Error, Result};
 
 /// An owned variant of `Threading::PROCESS_INFORMATION`.
 pub struct ProcessInformation {
@@ -31,7 +32,7 @@ pub fn arbitrary_process<'a>(
     env_vars: impl IntoIterator<Item = (String, String)>,
     args: impl IntoIterator<Item = &'a str>,
     create_suspended: bool,
-) -> anyhow::Result<ProcessInformation> {
+) -> Result<ProcessInformation> {
     let startup_info = Threading::STARTUPINFOW::default();
     let mut process_info = Threading::PROCESS_INFORMATION::default();
 
@@ -79,7 +80,7 @@ pub fn arbitrary_process<'a>(
             &mut process_info,
         )
         .map(|_| process_info.into())
-        .context("failed to spawn process")
+        .map_err(|e| Error::SpawnProcess { source: e })
     }
 }
 
@@ -89,12 +90,12 @@ pub fn steam_process<'a>(
     executable_path_builder: impl Fn(&Path) -> PathBuf + Copy,
     args: impl IntoIterator<Item = &'a str>,
     create_suspended: bool,
-) -> anyhow::Result<ProcessInformation> {
+) -> Result<ProcessInformation> {
     let steam_dir = steamlocate::SteamDir::locate()?;
 
     let (app, library) = steam_dir
         .find_app(app_id)?
-        .context("failed to locate app")?;
+        .ok_or(Error::SteamAppNotFound { app_id })?;
     let game_path = library.resolve_app_dir(&app);
     let executable_path = executable_path_builder(&game_path);
 

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -4,8 +4,6 @@ name = "re-utilities"
 version = "0.1.0"
 
 [dependencies]
-anyhow = { workspace = true }
-
 patternscan = "1.2.0"
 retour = { git = "https://github.com/Hpmason/retour-rs.git" }
 

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -5,9 +5,11 @@ version = "0.1.0"
 
 [dependencies]
 patternscan = "1.2.0"
+
+[target.'cfg(windows)'.dependencies]
 retour = { git = "https://github.com/Hpmason/retour-rs.git" }
 
-[dependencies.windows]
+[target.'cfg(windows)'.dependencies.windows]
 features = [
   "Win32_Foundation",
   "Win32_Security",

--- a/utilities/src/error.rs
+++ b/utilities/src/error.rs
@@ -1,0 +1,127 @@
+use std::fmt;
+
+/// Error type for re-utilities operations
+#[derive(Debug)]
+pub enum Error {
+    /// Pattern scan failed to find a match
+    PatternScanFailed { context: Option<String> },
+    /// Module path could not be retrieved
+    ModulePathUnavailable,
+    /// Failed to create a thread snapshot
+    ThreadSnapshotFailed { source: windows::core::Error },
+    /// Failed to open a thread
+    ThreadOpenFailed { source: windows::core::Error },
+    /// Failed to unpatch at the given address
+    UnpatchFailed { address: usize },
+    /// Detour operation failed
+    DetourFailed { source: retour::Error },
+    /// I/O operation failed
+    Io {
+        context: Option<String>,
+        source: std::io::Error,
+    },
+    /// Pattern scan library error
+    PatternScan { source: patternscan::Error },
+    /// Array conversion failed
+    ArrayConversion {
+        source: std::array::TryFromSliceError,
+    },
+    /// Integer conversion failed
+    IntConversion { source: std::num::TryFromIntError },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::PatternScanFailed { context } => {
+                if let Some(ctx) = context {
+                    write!(f, "pattern scan failed: {}", ctx)
+                } else {
+                    write!(f, "pattern scan failed")
+                }
+            }
+            Error::ModulePathUnavailable => {
+                write!(f, "module path unavailable")
+            }
+            Error::ThreadSnapshotFailed { source } => {
+                write!(f, "failed to create thread snapshot: {}", source)
+            }
+            Error::ThreadOpenFailed { source } => {
+                write!(f, "failed to open thread: {}", source)
+            }
+            Error::UnpatchFailed { address } => {
+                write!(f, "failed to unpatch at address 0x{:x}", address)
+            }
+            Error::DetourFailed { source } => {
+                write!(f, "detour operation failed: {}", source)
+            }
+            Error::Io { context, source } => {
+                if let Some(ctx) = context {
+                    write!(f, "{}: {}", ctx, source)
+                } else {
+                    write!(f, "I/O error: {}", source)
+                }
+            }
+            Error::PatternScan { source } => {
+                write!(f, "pattern scan error: {}", source)
+            }
+            Error::ArrayConversion { source } => {
+                write!(f, "array conversion failed: {}", source)
+            }
+            Error::IntConversion { source } => {
+                write!(f, "integer conversion failed: {}", source)
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::ThreadSnapshotFailed { source } => Some(source),
+            Error::ThreadOpenFailed { source } => Some(source),
+            Error::DetourFailed { source } => Some(source),
+            Error::Io { source, .. } => Some(source),
+            Error::PatternScan { source } => Some(source),
+            Error::ArrayConversion { source } => Some(source),
+            Error::IntConversion { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl From<retour::Error> for Error {
+    fn from(source: retour::Error) -> Self {
+        Error::DetourFailed { source }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(source: std::io::Error) -> Self {
+        Error::Io {
+            context: None,
+            source,
+        }
+    }
+}
+
+impl From<patternscan::Error> for Error {
+    fn from(source: patternscan::Error) -> Self {
+        Error::PatternScan { source }
+    }
+}
+
+impl From<std::array::TryFromSliceError> for Error {
+    fn from(source: std::array::TryFromSliceError) -> Self {
+        Error::ArrayConversion { source }
+    }
+}
+
+impl From<std::num::TryFromIntError> for Error {
+    fn from(source: std::num::TryFromIntError) -> Self {
+        Error::IntConversion { source }
+    }
+}
+
+/// Result type alias for re-utilities operations
+pub type Result<T> = std::result::Result<T, Error>;

--- a/utilities/src/error.rs
+++ b/utilities/src/error.rs
@@ -165,3 +165,6 @@ impl From<WindowsError> for Error {
 
 /// Result type alias for re-utilities operations
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// Result type alias for user-provided callbacks
+pub type UserCallbackResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/utilities/src/error.rs
+++ b/utilities/src/error.rs
@@ -1,5 +1,39 @@
 use std::fmt;
 
+/// Windows-specific errors
+#[cfg(target_os = "windows")]
+#[derive(Debug)]
+pub enum WindowsError {
+    /// Failed to create a thread snapshot
+    ThreadSnapshotFailed { source: windows::core::Error },
+    /// Failed to open a thread
+    ThreadOpenFailed { source: windows::core::Error },
+}
+
+#[cfg(target_os = "windows")]
+impl fmt::Display for WindowsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WindowsError::ThreadSnapshotFailed { source } => {
+                write!(f, "failed to create thread snapshot: {}", source)
+            }
+            WindowsError::ThreadOpenFailed { source } => {
+                write!(f, "failed to open thread: {}", source)
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl std::error::Error for WindowsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            WindowsError::ThreadSnapshotFailed { source } => Some(source),
+            WindowsError::ThreadOpenFailed { source } => Some(source),
+        }
+    }
+}
+
 /// Error type for re-utilities operations
 #[derive(Debug)]
 pub enum Error {
@@ -7,13 +41,10 @@ pub enum Error {
     PatternScanFailed { context: Option<String> },
     /// Module path could not be retrieved
     ModulePathUnavailable,
-    /// Failed to create a thread snapshot
-    ThreadSnapshotFailed { source: windows::core::Error },
-    /// Failed to open a thread
-    ThreadOpenFailed { source: windows::core::Error },
     /// Failed to unpatch at the given address
     UnpatchFailed { address: usize },
     /// Detour operation failed
+    #[cfg(target_os = "windows")]
     DetourFailed { source: retour::Error },
     /// I/O operation failed
     Io {
@@ -28,6 +59,9 @@ pub enum Error {
     },
     /// Integer conversion failed
     IntConversion { source: std::num::TryFromIntError },
+    /// Windows-specific error
+    #[cfg(target_os = "windows")]
+    Windows(WindowsError),
 }
 
 impl fmt::Display for Error {
@@ -43,15 +77,10 @@ impl fmt::Display for Error {
             Error::ModulePathUnavailable => {
                 write!(f, "module path unavailable")
             }
-            Error::ThreadSnapshotFailed { source } => {
-                write!(f, "failed to create thread snapshot: {}", source)
-            }
-            Error::ThreadOpenFailed { source } => {
-                write!(f, "failed to open thread: {}", source)
-            }
             Error::UnpatchFailed { address } => {
                 write!(f, "failed to unpatch at address 0x{:x}", address)
             }
+            #[cfg(target_os = "windows")]
             Error::DetourFailed { source } => {
                 write!(f, "detour operation failed: {}", source)
             }
@@ -71,6 +100,8 @@ impl fmt::Display for Error {
             Error::IntConversion { source } => {
                 write!(f, "integer conversion failed: {}", source)
             }
+            #[cfg(target_os = "windows")]
+            Error::Windows(e) => write!(f, "{}", e),
         }
     }
 }
@@ -78,18 +109,20 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::ThreadSnapshotFailed { source } => Some(source),
-            Error::ThreadOpenFailed { source } => Some(source),
+            #[cfg(target_os = "windows")]
             Error::DetourFailed { source } => Some(source),
             Error::Io { source, .. } => Some(source),
             Error::PatternScan { source } => Some(source),
             Error::ArrayConversion { source } => Some(source),
             Error::IntConversion { source } => Some(source),
+            #[cfg(target_os = "windows")]
+            Error::Windows(e) => e.source(),
             _ => None,
         }
     }
 }
 
+#[cfg(target_os = "windows")]
 impl From<retour::Error> for Error {
     fn from(source: retour::Error) -> Self {
         Error::DetourFailed { source }
@@ -120,6 +153,13 @@ impl From<std::array::TryFromSliceError> for Error {
 impl From<std::num::TryFromIntError> for Error {
     fn from(source: std::num::TryFromIntError) -> Self {
         Error::IntConversion { source }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl From<WindowsError> for Error {
+    fn from(source: WindowsError) -> Self {
+        Error::Windows(source)
     }
 }
 

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -10,4 +10,4 @@ pub use crate::windows::*;
 #[cfg(target_os = "windows")]
 pub use retour;
 
-pub use error::{Error, Result};
+pub use error::{Error, Result, UserCallbackResult};

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod util;
 
 #[cfg(target_os = "windows")]
@@ -9,5 +10,4 @@ pub use crate::windows::*;
 #[cfg(target_os = "windows")]
 pub use retour;
 
-#[cfg(target_os = "windows")]
-pub use anyhow;
+pub use error::{Error, Result};

--- a/utilities/src/util.rs
+++ b/utilities/src/util.rs
@@ -17,7 +17,7 @@ macro_rules! singleton {
         static mut INSTANCE: Option<$class_name> = None;
 
         impl $class_name {
-            pub fn create($($arg_name : $arg_type),*) -> anyhow::Result<()> {
+            pub fn create($($arg_name : $arg_type),*) -> ::re_utilities::Result<()> {
                 unsafe {
                     INSTANCE = Some(<$class_name>::new( $($arg_name),* )?);
                 }

--- a/utilities/src/windows/detour_binder.rs
+++ b/utilities/src/windows/detour_binder.rs
@@ -1,5 +1,8 @@
 use crate::error::Result;
 
+/// Type alias for user-specified error results
+pub type UserResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
 pub trait DetourBinder {
     fn enable(&self) -> Result<()>;
     fn disable(&self) -> Result<()>;

--- a/utilities/src/windows/detour_binder.rs
+++ b/utilities/src/windows/detour_binder.rs
@@ -1,30 +1,32 @@
+use crate::error::Result;
+
 pub trait DetourBinder {
-    fn enable(&self) -> anyhow::Result<()>;
-    fn disable(&self) -> anyhow::Result<()>;
+    fn enable(&self) -> Result<()>;
+    fn disable(&self) -> Result<()>;
 }
 
 pub struct CompiletimeDetourBinder {
-    pub enable: &'static (dyn Send + Sync + Fn() -> anyhow::Result<()>),
-    pub disable: &'static (dyn Send + Sync + Fn() -> anyhow::Result<()>),
+    pub enable: &'static (dyn Send + Sync + Fn() -> Result<()>),
+    pub disable: &'static (dyn Send + Sync + Fn() -> Result<()>),
 }
 impl DetourBinder for CompiletimeDetourBinder {
-    fn enable(&self) -> anyhow::Result<()> {
+    fn enable(&self) -> Result<()> {
         (self.enable)()
     }
-    fn disable(&self) -> anyhow::Result<()> {
+    fn disable(&self) -> Result<()> {
         (self.disable)()
     }
 }
 
 pub struct RuntimeDetourBinder {
-    pub enable: Box<dyn Send + Sync + Fn() -> anyhow::Result<()>>,
-    pub disable: Box<dyn Send + Sync + Fn() -> anyhow::Result<()>>,
+    pub enable: Box<dyn Send + Sync + Fn() -> Result<()>>,
+    pub disable: Box<dyn Send + Sync + Fn() -> Result<()>>,
 }
 impl DetourBinder for RuntimeDetourBinder {
-    fn enable(&self) -> anyhow::Result<()> {
+    fn enable(&self) -> Result<()> {
         (self.enable)()
     }
-    fn disable(&self) -> anyhow::Result<()> {
+    fn disable(&self) -> Result<()> {
         (self.disable)()
     }
 }

--- a/utilities/src/windows/detour_binder.rs
+++ b/utilities/src/windows/detour_binder.rs
@@ -1,35 +1,32 @@
-use crate::error::Result;
-
-/// Type alias for user-specified error results
-pub type UserResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+use crate::error::UserCallbackResult;
 
 pub trait DetourBinder {
-    fn enable(&self) -> Result<()>;
-    fn disable(&self) -> Result<()>;
+    fn enable(&self) -> UserCallbackResult<()>;
+    fn disable(&self) -> UserCallbackResult<()>;
 }
 
 pub struct CompiletimeDetourBinder {
-    pub enable: &'static (dyn Send + Sync + Fn() -> Result<()>),
-    pub disable: &'static (dyn Send + Sync + Fn() -> Result<()>),
+    pub enable: &'static (dyn Send + Sync + Fn() -> UserCallbackResult<()>),
+    pub disable: &'static (dyn Send + Sync + Fn() -> UserCallbackResult<()>),
 }
 impl DetourBinder for CompiletimeDetourBinder {
-    fn enable(&self) -> Result<()> {
+    fn enable(&self) -> UserCallbackResult<()> {
         (self.enable)()
     }
-    fn disable(&self) -> Result<()> {
+    fn disable(&self) -> UserCallbackResult<()> {
         (self.disable)()
     }
 }
 
 pub struct RuntimeDetourBinder {
-    pub enable: Box<dyn Send + Sync + Fn() -> Result<()>>,
-    pub disable: Box<dyn Send + Sync + Fn() -> Result<()>>,
+    pub enable: Box<dyn Send + Sync + Fn() -> UserCallbackResult<()>>,
+    pub disable: Box<dyn Send + Sync + Fn() -> UserCallbackResult<()>>,
 }
 impl DetourBinder for RuntimeDetourBinder {
-    fn enable(&self) -> Result<()> {
+    fn enable(&self) -> UserCallbackResult<()> {
         (self.enable)()
     }
-    fn disable(&self) -> Result<()> {
+    fn disable(&self) -> UserCallbackResult<()> {
         (self.disable)()
     }
 }

--- a/utilities/src/windows/hook_library.rs
+++ b/utilities/src/windows/hook_library.rs
@@ -1,14 +1,23 @@
 use super::{
-    detour_binder::{DetourBinder, RuntimeDetourBinder},
+    detour_binder::{DetourBinder, RuntimeDetourBinder, UserResult},
     patcher::Patcher,
 };
 
-use crate::error::{Error, Result};
+use crate::error::Error;
+
+/// Type alias for results that can contain any error type
+pub type BoxedResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+struct UserCallback {
+    enable: Box<dyn Fn() -> UserResult<()> + Send + Sync>,
+    disable: Box<dyn Fn() -> UserResult<()> + Send + Sync>,
+}
 
 #[allow(clippy::type_complexity)]
 pub struct HookLibrary {
     static_binders: Vec<&'static dyn DetourBinder>,
     runtime_binders: Vec<Box<dyn DetourBinder>>,
+    user_callbacks: Vec<UserCallback>,
     patches: Vec<(usize, Vec<u8>)>,
 }
 impl HookLibrary {
@@ -17,6 +26,7 @@ impl HookLibrary {
         HookLibrary {
             static_binders: vec![],
             runtime_binders: vec![],
+            user_callbacks: vec![],
             patches: vec![],
         }
     }
@@ -48,24 +58,28 @@ impl HookLibrary {
         }))
     }
     pub fn with_callbacks(
-        self,
-        enable: impl Fn() -> Result<()> + Send + Sync + 'static,
-        disable: impl Fn() -> Result<()> + Send + Sync + 'static,
+        mut self,
+        enable: impl Fn() -> UserResult<()> + Send + Sync + 'static,
+        disable: impl Fn() -> UserResult<()> + Send + Sync + 'static,
     ) -> Self {
-        self.with_runtime_binder(Box::new(RuntimeDetourBinder {
+        self.user_callbacks.push(UserCallback {
             enable: Box::new(enable),
             disable: Box::new(disable),
-        }))
+        });
+        self
     }
     pub fn with_patch(mut self, address: usize, bytes: &[u8]) -> Self {
         self.patches.push((address, bytes.to_owned()));
         self
     }
 
-    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> Result<()> {
+    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> BoxedResult<()> {
         if enabled {
             for binder in self.binders() {
                 binder.enable()?;
+            }
+            for cb in &self.user_callbacks {
+                (cb.enable)()?;
             }
             for (address, patch) in &self.patches {
                 unsafe {
@@ -79,6 +93,9 @@ impl HookLibrary {
                         .unpatch(*address)
                         .ok_or(Error::UnpatchFailed { address: *address })?;
                 }
+            }
+            for cb in &self.user_callbacks {
+                (cb.disable)()?;
             }
             for binder in self.binders() {
                 binder.disable()?;
@@ -102,6 +119,9 @@ impl Default for HookLibrary {
 }
 impl Drop for HookLibrary {
     fn drop(&mut self) {
+        for cb in &self.user_callbacks {
+            let _ = (cb.disable)();
+        }
         for binder in self.binders() {
             let _ = binder.disable();
         }
@@ -113,13 +133,13 @@ impl HookLibraries {
     pub fn new(libraries: impl Into<Vec<HookLibrary>>) -> HookLibraries {
         HookLibraries(libraries.into())
     }
-    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> Result<()> {
+    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> BoxedResult<()> {
         for library in &self.0 {
             library.set_enabled(patcher, enabled)?;
         }
         Ok(())
     }
-    pub fn enable(self, patcher: &mut Patcher) -> Result<Self> {
+    pub fn enable(self, patcher: &mut Patcher) -> BoxedResult<Self> {
         self.set_enabled(patcher, true)?;
         Ok(self)
     }

--- a/utilities/src/windows/hook_library.rs
+++ b/utilities/src/windows/hook_library.rs
@@ -3,7 +3,7 @@ use super::{
     patcher::Patcher,
 };
 
-use anyhow::Context;
+use crate::error::{Error, Result};
 
 #[allow(clippy::type_complexity)]
 pub struct HookLibrary {
@@ -49,8 +49,8 @@ impl HookLibrary {
     }
     pub fn with_callbacks(
         self,
-        enable: impl Fn() -> anyhow::Result<()> + Send + Sync + 'static,
-        disable: impl Fn() -> anyhow::Result<()> + Send + Sync + 'static,
+        enable: impl Fn() -> Result<()> + Send + Sync + 'static,
+        disable: impl Fn() -> Result<()> + Send + Sync + 'static,
     ) -> Self {
         self.with_runtime_binder(Box::new(RuntimeDetourBinder {
             enable: Box::new(enable),
@@ -62,7 +62,7 @@ impl HookLibrary {
         self
     }
 
-    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> anyhow::Result<()> {
+    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> Result<()> {
         if enabled {
             for binder in self.binders() {
                 binder.enable()?;
@@ -75,7 +75,9 @@ impl HookLibrary {
         } else {
             for (address, _) in &self.patches {
                 unsafe {
-                    patcher.unpatch(*address).context("failed to unpatch")?;
+                    patcher
+                        .unpatch(*address)
+                        .ok_or(Error::UnpatchFailed { address: *address })?;
                 }
             }
             for binder in self.binders() {
@@ -111,13 +113,13 @@ impl HookLibraries {
     pub fn new(libraries: impl Into<Vec<HookLibrary>>) -> HookLibraries {
         HookLibraries(libraries.into())
     }
-    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> anyhow::Result<()> {
+    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> Result<()> {
         for library in &self.0 {
             library.set_enabled(patcher, enabled)?;
         }
         Ok(())
     }
-    pub fn enable(self, patcher: &mut Patcher) -> anyhow::Result<Self> {
+    pub fn enable(self, patcher: &mut Patcher) -> Result<Self> {
         self.set_enabled(patcher, true)?;
         Ok(self)
     }

--- a/utilities/src/windows/hook_library.rs
+++ b/utilities/src/windows/hook_library.rs
@@ -1,23 +1,43 @@
+use std::fmt;
+
 use super::{
-    detour_binder::{DetourBinder, RuntimeDetourBinder, UserResult},
+    detour_binder::{DetourBinder, RuntimeDetourBinder},
     patcher::Patcher,
 };
 
-use crate::error::Error;
+use crate::error::{Error, UserCallbackResult};
 
-/// Type alias for results that can contain any error type
-pub type BoxedResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+/// Error type for HookLibrary operations
+#[derive(Debug)]
+pub enum HookLibraryError {
+    /// Standard library error
+    Standard(Error),
+    /// User callback error
+    UserCallback(Box<dyn std::error::Error + Send + Sync>),
+}
 
-struct UserCallback {
-    enable: Box<dyn Fn() -> UserResult<()> + Send + Sync>,
-    disable: Box<dyn Fn() -> UserResult<()> + Send + Sync>,
+impl fmt::Display for HookLibraryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HookLibraryError::Standard(e) => write!(f, "{}", e),
+            HookLibraryError::UserCallback(e) => write!(f, "user callback error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for HookLibraryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            HookLibraryError::Standard(e) => e.source(),
+            HookLibraryError::UserCallback(e) => e.source(),
+        }
+    }
 }
 
 #[allow(clippy::type_complexity)]
 pub struct HookLibrary {
     static_binders: Vec<&'static dyn DetourBinder>,
     runtime_binders: Vec<Box<dyn DetourBinder>>,
-    user_callbacks: Vec<UserCallback>,
     patches: Vec<(usize, Vec<u8>)>,
 }
 impl HookLibrary {
@@ -26,7 +46,6 @@ impl HookLibrary {
         HookLibrary {
             static_binders: vec![],
             runtime_binders: vec![],
-            user_callbacks: vec![],
             patches: vec![],
         }
     }
@@ -43,43 +62,33 @@ impl HookLibrary {
         detour: &'static retour::GenericDetour<F>,
     ) -> Self {
         self.with_runtime_binder(Box::new(RuntimeDetourBinder {
-            enable: Box::new(|| {
-                unsafe {
-                    detour.enable()?;
-                }
-                Ok(())
-            }),
-            disable: Box::new(|| {
-                unsafe {
-                    detour.disable()?;
-                }
-                Ok(())
-            }),
+            enable: Box::new(|| unsafe { detour.enable().map_err(|e| Box::new(e) as _) }),
+            disable: Box::new(|| unsafe { detour.disable().map_err(|e| Box::new(e) as _) }),
         }))
     }
     pub fn with_callbacks(
-        mut self,
-        enable: impl Fn() -> UserResult<()> + Send + Sync + 'static,
-        disable: impl Fn() -> UserResult<()> + Send + Sync + 'static,
+        self,
+        enable: impl Fn() -> UserCallbackResult<()> + Send + Sync + 'static,
+        disable: impl Fn() -> UserCallbackResult<()> + Send + Sync + 'static,
     ) -> Self {
-        self.user_callbacks.push(UserCallback {
+        self.with_runtime_binder(Box::new(RuntimeDetourBinder {
             enable: Box::new(enable),
             disable: Box::new(disable),
-        });
-        self
+        }))
     }
     pub fn with_patch(mut self, address: usize, bytes: &[u8]) -> Self {
         self.patches.push((address, bytes.to_owned()));
         self
     }
 
-    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> BoxedResult<()> {
+    pub fn set_enabled(
+        &self,
+        patcher: &mut Patcher,
+        enabled: bool,
+    ) -> Result<(), HookLibraryError> {
         if enabled {
             for binder in self.binders() {
-                binder.enable()?;
-            }
-            for cb in &self.user_callbacks {
-                (cb.enable)()?;
+                binder.enable().map_err(HookLibraryError::UserCallback)?;
             }
             for (address, patch) in &self.patches {
                 unsafe {
@@ -89,16 +98,13 @@ impl HookLibrary {
         } else {
             for (address, _) in &self.patches {
                 unsafe {
-                    patcher
-                        .unpatch(*address)
-                        .ok_or(Error::UnpatchFailed { address: *address })?;
+                    patcher.unpatch(*address).ok_or_else(|| {
+                        HookLibraryError::Standard(Error::UnpatchFailed { address: *address })
+                    })?;
                 }
             }
-            for cb in &self.user_callbacks {
-                (cb.disable)()?;
-            }
             for binder in self.binders() {
-                binder.disable()?;
+                binder.disable().map_err(HookLibraryError::UserCallback)?;
             }
         }
         Ok(())
@@ -119,9 +125,6 @@ impl Default for HookLibrary {
 }
 impl Drop for HookLibrary {
     fn drop(&mut self) {
-        for cb in &self.user_callbacks {
-            let _ = (cb.disable)();
-        }
         for binder in self.binders() {
             let _ = binder.disable();
         }
@@ -133,13 +136,17 @@ impl HookLibraries {
     pub fn new(libraries: impl Into<Vec<HookLibrary>>) -> HookLibraries {
         HookLibraries(libraries.into())
     }
-    pub fn set_enabled(&self, patcher: &mut Patcher, enabled: bool) -> BoxedResult<()> {
+    pub fn set_enabled(
+        &self,
+        patcher: &mut Patcher,
+        enabled: bool,
+    ) -> Result<(), HookLibraryError> {
         for library in &self.0 {
             library.set_enabled(patcher, enabled)?;
         }
         Ok(())
     }
-    pub fn enable(self, patcher: &mut Patcher) -> BoxedResult<Self> {
+    pub fn enable(self, patcher: &mut Patcher) -> Result<Self, HookLibraryError> {
         self.set_enabled(patcher, true)?;
         Ok(self)
     }

--- a/utilities/src/windows/module.rs
+++ b/utilities/src/windows/module.rs
@@ -9,7 +9,7 @@ use windows::Win32::{
     },
 };
 
-use anyhow::anyhow;
+use crate::error::{Error, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum CacheKey {
@@ -102,7 +102,7 @@ impl Module {
     }
 
     #[allow(dead_code)]
-    pub fn hash(&self) -> anyhow::Result<u64> {
+    pub fn hash(&self) -> Result<u64> {
         use std::{collections::hash_map::DefaultHasher, fs::File, hash::Hasher};
 
         struct HashWriter<T: Hasher>(T);
@@ -122,10 +122,7 @@ impl Module {
             }
         }
 
-        let input = File::open(
-            self.path()
-                .ok_or_else(|| anyhow!("can't open module for hashing"))?,
-        )?;
+        let input = File::open(self.path().ok_or(Error::ModulePathUnavailable)?)?;
         let mut reader = io::BufReader::new(input);
 
         let mut hw = HashWriter(DefaultHasher::new());
@@ -134,12 +131,15 @@ impl Module {
         Ok(hw.0.finish())
     }
 
-    pub fn scan(&mut self, pattern: &str) -> anyhow::Result<*mut u8> {
+    pub fn scan(&mut self, pattern: &str) -> Result<*mut u8> {
         let offset = if let Some(offset) = self.cache.get(&CacheKey::Regular(pattern.to_owned())) {
             *offset
         } else {
-            patternscan::scan_first_match(io::Cursor::new(self.as_bytes()), pattern)?
-                .ok_or_else(|| anyhow!("failed to scan"))?
+            patternscan::scan_first_match(io::Cursor::new(self.as_bytes()), pattern)?.ok_or(
+                Error::PatternScanFailed {
+                    context: Some(format!("pattern: {}", pattern)),
+                },
+            )?
         };
 
         self.cache
@@ -148,11 +148,7 @@ impl Module {
         Ok(self.rel_to_abs_addr(offset))
     }
 
-    pub fn scan_for_relative_callsite(
-        &self,
-        pattern: &str,
-        addr_offset: usize,
-    ) -> anyhow::Result<*mut u8> {
+    pub fn scan_for_relative_callsite(&self, pattern: &str, addr_offset: usize) -> Result<*mut u8> {
         let offset = if let Some(offset) = self
             .cache
             .get(&CacheKey::RelativeCallsite(pattern.to_owned()))
@@ -160,7 +156,9 @@ impl Module {
             *offset
         } else {
             let offset = patternscan::scan_first_match(io::Cursor::new(self.as_bytes()), pattern)?
-                .ok_or_else(|| anyhow!("failed to scan"))?;
+                .ok_or(Error::PatternScanFailed {
+                    context: Some(format!("pattern: {}", pattern)),
+                })?;
             let base = self.rel_to_abs_addr(offset + addr_offset);
             let call = unsafe { slice::from_raw_parts(base as *const u8, 4) };
             let offset = i32::from_ne_bytes(call.try_into()?) + 4;
@@ -173,7 +171,7 @@ impl Module {
     }
 
     #[allow(dead_code)]
-    pub fn scan_after_ptr(&mut self, base: *const u8, pattern: &str) -> anyhow::Result<*mut u8> {
+    pub fn scan_after_ptr(&mut self, base: *const u8, pattern: &str) -> Result<*mut u8> {
         let base_offset = self.abs_to_rel_addr(base) as usize;
 
         let offset = if let Some(offset) = self
@@ -185,7 +183,9 @@ impl Module {
             let slice = &self.as_bytes()[base_offset..];
 
             let offset_from_base = patternscan::scan_first_match(io::Cursor::new(slice), pattern)?
-                .ok_or_else(|| anyhow!("failed to scan"))?;
+                .ok_or(Error::PatternScanFailed {
+                    context: Some(format!("pattern: {}", pattern)),
+                })?;
 
             base_offset + offset_from_base
         };

--- a/utilities/src/windows/thread_suspender.rs
+++ b/utilities/src/windows/thread_suspender.rs
@@ -13,7 +13,7 @@ use windows::Win32::{
     },
 };
 
-use crate::error::{Error, Result};
+use crate::error::{Result, WindowsError};
 
 pub struct ThreadSuspender {
     threads: Vec<HANDLE>,
@@ -22,8 +22,11 @@ impl ThreadSuspender {
     pub fn new() -> Result<Self> {
         let process_id = unsafe { GetCurrentProcessId() };
         let handle = unsafe {
-            CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, process_id)
-                .map_err(|e| Error::ThreadSnapshotFailed { source: e })?
+            CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, process_id).map_err(
+                |e| -> crate::error::Error {
+                    WindowsError::ThreadSnapshotFailed { source: e }.into()
+                },
+            )?
         };
 
         fn from_snapshot<Value: Default + Copy + Sized>(
@@ -54,7 +57,7 @@ impl ThreadSuspender {
             })
             .map(|thread| unsafe {
                 OpenThread(THREAD_ALL_ACCESS, false, thread.th32ThreadID)
-                    .map_err(|e| Error::ThreadOpenFailed { source: e })
+                    .map_err(|e| WindowsError::ThreadOpenFailed { source: e }.into())
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/utilities/src/windows/thread_suspender.rs
+++ b/utilities/src/windows/thread_suspender.rs
@@ -1,6 +1,5 @@
 use std::mem;
 
-use anyhow::Context;
 use windows::Win32::{
     Foundation::{CloseHandle, HANDLE},
     System::{
@@ -14,15 +13,17 @@ use windows::Win32::{
     },
 };
 
+use crate::error::{Error, Result};
+
 pub struct ThreadSuspender {
     threads: Vec<HANDLE>,
 }
 impl ThreadSuspender {
-    pub fn new() -> anyhow::Result<Self> {
+    pub fn new() -> Result<Self> {
         let process_id = unsafe { GetCurrentProcessId() };
         let handle = unsafe {
             CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, process_id)
-                .context("failed to create snapshot of process")?
+                .map_err(|e| Error::ThreadSnapshotFailed { source: e })?
         };
 
         fn from_snapshot<Value: Default + Copy + Sized>(
@@ -51,8 +52,11 @@ impl ThreadSuspender {
             .filter(|thread| {
                 thread.th32OwnerProcessID == process_id && thread.th32ThreadID != thread_id
             })
-            .map(|thread| unsafe { OpenThread(THREAD_ALL_ACCESS, false, thread.th32ThreadID) })
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|thread| unsafe {
+                OpenThread(THREAD_ALL_ACCESS, false, thread.th32ThreadID)
+                    .map_err(|e| Error::ThreadOpenFailed { source: e })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         Self::suspend(&threads);
         Ok(Self { threads })
@@ -78,7 +82,7 @@ impl ThreadSuspender {
             unsafe { CloseHandle(*handle).unwrap() };
         }
     }
-    pub fn for_block<T>(mut f: impl FnMut() -> anyhow::Result<T>) -> anyhow::Result<T> {
+    pub fn for_block<T>(mut f: impl FnMut() -> Result<T>) -> Result<T> {
         let _suspender = ThreadSuspender::new()?;
         f()
     }

--- a/utilities/src/windows/thread_suspender.rs
+++ b/utilities/src/windows/thread_suspender.rs
@@ -13,7 +13,7 @@ use windows::Win32::{
     },
 };
 
-use crate::error::{Result, WindowsError};
+use crate::error::{Result, UserCallbackResult, WindowsError};
 
 pub struct ThreadSuspender {
     threads: Vec<HANDLE>,
@@ -85,7 +85,7 @@ impl ThreadSuspender {
             unsafe { CloseHandle(*handle).unwrap() };
         }
     }
-    pub fn for_block<T>(mut f: impl FnMut() -> Result<T>) -> Result<T> {
+    pub fn for_block<T>(mut f: impl FnMut() -> UserCallbackResult<T>) -> UserCallbackResult<T> {
         let _suspender = ThreadSuspender::new()?;
         f()
     }


### PR DESCRIPTION
Replace the anyhow dependency with manually implemented error enums for both the utilities and injector crates. This provides more descriptive and typed error handling without relying on external error libraries.

- Add Error and Result types to utilities/src/error.rs
- Add Error and Result types to injector/src/error.rs
- Update detours-macro to use the new error types
- Remove anyhow from all Cargo.toml files